### PR TITLE
Upgrade to cheerio 1.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,2 @@
 language: node_js
-node_js:
-  - 7.6
+node_js: node

--- a/fs-cheerio.js
+++ b/fs-cheerio.js
@@ -1,4 +1,4 @@
-var asap = require("pdenodeify");
+var asap = require("util").promisify;
 var fs = require("fs");
 var cheerio = require("cheerio");
 var readFile = asap(fs.readFile);

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
   },
   "homepage": "https://github.com/matthewp/fs-cheerio",
   "dependencies": {
-    "cheerio": "^0.22.0",
-    "pdenodeify": "^0.1.0"
+    "cheerio": "^1.0.0-rc.2"
   },
   "devDependencies": {
     "tap-spec": "^4.1.0",

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-const asap = require("pdenodeify");
+const asap = require("util").promisify;
 const fs = require("fs");
 const fsc = require("../fs-cheerio");
 const test = require("tape");


### PR DESCRIPTION
This upgrades the major release of cheerio, and also uses the native
util.promisify now.